### PR TITLE
Fixing bus freezing issue by adding all implementations of println()

### DIFF
--- a/Auto485.cpp
+++ b/Auto485.cpp
@@ -90,9 +90,99 @@ void Auto485::flush(void)
 	set_mode(RX);
 }
 
+
 size_t Auto485::println(void)
 {
 	 size_t n = Print::println();
-	 set_mode(RX);
+         set_mode(RX);
 	 return n;
+}
+
+size_t Auto485::println(const String &s)
+{
+	size_t n = Print::print(s);
+	n += Print::println();
+	set_mode(RX);
+	return n;
+}
+
+size_t Auto485::println(const __FlashStringHelper *ifsh)
+{
+  size_t n = Print::print(ifsh);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(const char c[])
+{
+  size_t n = Auto485::print(c);
+  n += Auto485::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(char c)
+{
+  size_t n = Print::print(c);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+
+size_t Auto485::println(const Printable& x)
+{
+  size_t n = Print::print(x);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(unsigned char b, int base)
+{
+  size_t n = Print::print(b, base);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(int num, int base)
+{
+  size_t n = Print::print(num, base);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(unsigned int num, int base)
+{
+  size_t n = Print::print(num, base);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(long num, int base)
+{
+  size_t n = Print::print(num, base);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(unsigned long num, int base)
+{
+  size_t n = Print::print(num, base);
+  n += Print::println();
+  set_mode(RX);
+  return n;
+}
+
+size_t Auto485::println(double num, int digits)
+{
+  size_t n = Print::print(num, digits);
+  n += Print::println();
+  set_mode(RX);
+  return n;
 }

--- a/Auto485.h
+++ b/Auto485.h
@@ -48,7 +48,18 @@ class Auto485 : public Stream
 		int     available(void);
 		int     peek(void);
 		int     read(void);
-		size_t  println(void);
+		size_t println(const __FlashStringHelper *);
+    		size_t println(const String &s);
+    		size_t println(const char[]);
+    		size_t println(char);
+    		size_t println(unsigned char, int = DEC);
+    		size_t println(int, int = DEC);
+    		size_t println(unsigned int, int = DEC);
+    		size_t println(long, int = DEC);
+    		size_t println(unsigned long, int = DEC);
+    		size_t println(double, int = 2);
+    		size_t println(const Printable&);
+    		size_t println(void);
 		using   Print::println;
 		
 private:


### PR DESCRIPTION
Previously only println(void) was reimplemented inside ``Auto485.cpp``, and the rest were inherited from the parent ``Print`` class. This meant that once it finished printing, it never called ``set_mode(RX)`` to return the MAX485 chip to RX mode. So it was effectively freezing the entire bus by locking the MAX485 in TX mode until you manually called ``set_mode(RX)``. This commit implements all the versions of ``println `` that are in Print.h, and has been tested to compile and function correctly.

Fixes #1 