### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #########################################
 
-Auto485     KEYWORD1
+Auto485	KEYWORD1
 
 #########################################
 # Methods and Functions (KEYWORD2)
 #########################################
 
-begin       KEYWORD2
-end         KEYWORD2
-available   KEYWORD2
-peek        KEYWORD2
-read        KEYWORD2
-flush       KEYWORD2
-write       KEYWORD2
-set_mode    KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+available	KEYWORD2
+peek	KEYWORD2
+read	KEYWORD2
+flush	KEYWORD2
+write	KEYWORD2
+set_mode	KEYWORD2
 
 #########################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords