### PR TITLE
Fix ESP8266 compile error (issue #5)

### DIFF
--- a/Auto485.cpp
+++ b/Auto485.cpp
@@ -55,7 +55,11 @@ void Auto485::begin(unsigned long baud)
 
 void Auto485::begin(unsigned long baud, uint8_t config)
 {
+#ifdef ESP8266
+	_serial.begin(baud, (SerialConfig)config);
+#else
 	_serial.begin(baud, config);
+#endif
 }
 
 void Auto485::end(void) {


### PR DESCRIPTION
### Problem
On ESP8266, `HardwareSerial::begin()` expects a `SerialConfig` enum for the config parameter, but Auto485 passes `uint8_t`, causing:
```
error: invalid conversion from 'uint8_t' to 'SerialConfig' [-fpermissive]
```
### Solution
Add a conditional cast to `SerialConfig` when compiling for ESP8266. Other platforms (AVR, STM32, ESP32, Uno R4, etc.) accept `uint8_t` without issue.

### Changes
- `Auto485.cpp`: Cast `config` to `SerialConfig` in `begin(unsigned long, uint8_t)` for ESP8266 only

Fixes #5 