### PR TITLE
Add library metadata files

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,25 @@
+{
+    "name": "Auto485",
+    "version": "1.0.0",
+    "description": "Auto485 - a small helper library that takes some of the tedium out of RS485 communication. It automatically handles the DE/RE pin toggling for half-duplex RS485 transceivers.",
+    "keywords": "RS485, communication, serial, auto485, arduino",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/madleech/Auto485.git"
+    },
+    "authors": [
+        {
+            "name": "Michael Adams",
+            "url": "http://www.michael.net.nz",
+            "maintainer": true
+        }
+    ],
+    "license": "MIT",
+    "frameworks": "arduino",
+    "platforms": "*",
+    "headers": "Auto485.h",
+    "build": {
+        "srcDir": ".",
+        "includeDir": "."
+    }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Auto485
+version=1.0.0
+author=Michael Adams
+maintainer=Michael Adams
+sentence=Helper library for RS485 communication
+paragraph=Auto485 is a small helper library that takes some of the tedium out of RS485 communication. It automatically handles the DE/RE pin toggling for half-duplex RS485 transceivers.
+category=Communication
+url=https://github.com/madleech/Auto485
+architectures=*
+includes=Auto485.h


### PR DESCRIPTION
## Summary

Add `library.properties` and `library.json` to enable automatic library discovery by Arduino IDE and PlatformIO.
Auto485 is missing the standard Arduino library metadata files required
for automatic discovery by Arduino IDE and PlatformIO.

## Changes

- **library.properties** — Standard Arduino library metadata (name, version, author, architectures, includes, etc.) as defined by the Arduino Library Specification.
- **library.json** — PlatformIO-compatible metadata for registry-based dependency resolution.

These files have no impact on compilation but are required by toolchains that discover libraries by scanning directories.
